### PR TITLE
Add instructions for ProtonUp-Qt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ Run Linux games as is, even if Valve recommends Proton for a game.
 
 # Installation
 
+
+## Install using ProtonUp-Qt
+
+1. Download [ProtonUp-Qt](https://davidotek.github.io/protonup-qt/) (You can find it in your app store via Flathub or click the link to download an AppImage)
+2. Enable advanced mode (press About > Enable advanced mode)
+3. Press `Add version` in the main dialog
+4. Select `Steam-Play-None` under `Compatibility tool` and press `Install`
+5. Set the compatibility-tool for the game in your library to `Steam-Play-None`
+
+## Install manually
+
 - Download this repository as an archive file: [Download](https://github.com/Scrumplex/Steam-Play-None/archive/refs/heads/main.tar.gz)
 - Extract it to `~/.steam/steam/compatibilitytools.d/`
 - Set the compatibility-tool for the game in your library to "None"


### PR DESCRIPTION
This PR adds instructions how Steam-Play-None can be installed using ProtonUp-Qt.

I've added support for installing Steam-Play-None to ProtonUp-Qt in https://github.com/DavidoTek/ProtonUp-Qt/pull/153. It will be available in the next release (est. v2.7.7).

[ProtonUp-Qt](https://github.com/DavidoTek/ProtonUp-Qt) is a GUI application that allows for easy installation of various compatibility tools like GE-Proton and SteamTinkerLaunch for game launchers like Steam on Linux.

PS: A bit off-topic: I was thinking that it might be a good idea to change the internal name from `none` to `Steam-Play-None`. This way it is consistent with the folder name which makes it easier for Steam(Deck) users to comprehend and simplifies the internal installation process in ProtonUp-Qt.